### PR TITLE
Dynamic floor tick width

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -422,7 +422,11 @@ impl CurrPlayers {
     }
 
     fn draw_floor_tick(&self, ui: &mut egui::Ui, pos: egui::Pos2) {
-        let xmm = self.get_x_min_max();
+        let window_width = ui.available_size().x;
+
+        let mut xmm = self.get_x_min_max();
+        xmm.y = xmm.y.max(window_width);
+
         let tl = pos2(xmm.x, pos.y - 1.0);
         let br = pos2(xmm.y, pos.y + 1.0);
         let rect = egui::Rect::from_two_pos(tl, br);


### PR DESCRIPTION
Update floor tick width on resize. Also for tiling window managers that force a particular width on start.

Before:

![image](https://github.com/XertroV/dd2-height-alarm/assets/34997667/d19dd0b4-aa84-40ff-af30-6ba89fcb9553)


After:

![image](https://github.com/XertroV/dd2-height-alarm/assets/34997667/64ec2f55-7c4a-4106-b040-4a266a80bdaa)
